### PR TITLE
Use `development` for the webpack mode even in production

### DIFF
--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -1,3 +1,4 @@
+ARG pods_csv=/dev/null
 ARG grafana_version=latest
 ARG grafana_image=grafana-enterprise
 
@@ -13,4 +14,10 @@ ENV GF_DEFAULT_APP_MODE "development"
 
 # Inject livereload script into grafana index.html
 USER root
+RUN grafana-cli plugins install marcusolsson-csv-datasource
+
+#  [plugin.marcusolsson-csv-datasource]
+#    allow_local_mode = true
+RUN echo -ne "[plugin.marcusolsson-csv-datasource]\n  allow_local_mode = true\n" >> /etc/grafana/grafana.ini
+COPY ${pods_csv} /tmp/pods.csv
 RUN sed -i 's|</body>|<script src="http://localhost:35729/livereload.js"></script></body>|g' /usr/share/grafana/public/views/index.html

--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -76,11 +76,6 @@ const config = async (env): Promise<Configuration> => {
     module: {
       rules: [
         {
-          test: /\.js$/,
-          enforce: "pre",
-          use: ["source-map-loader"],
-        },
-        {
           exclude: /(node_modules)/,
           test: /\.[tj]sx?$/,
           use: {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,18 @@ services:
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-10.3.3}
+    networks:
+      - grafana
     ports:
       - 4000:3000/tcp
+    external_links:
+      - prometheus-app:prom
+
     volumes:
       - ./dist:/var/lib/grafana/plugins/ekacnet-cubismgrafana-panel
       - ./provisioning:/etc/grafana/provisioning
+
+networks:
+  grafana:
+    name: grafanacubism-panel_default
+    attachable: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cubism-grafana-panel",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cubism-grafana-panel",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.10.6",
@@ -64,50 +64,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "../cubism-es": {
-      "version": "1.1.3",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "d3-axis": "2",
-        "d3-dispatch": "2",
-        "d3-fetch": "2",
-        "d3-format": "2",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-selection": "2",
-        "d3-time": "2",
-        "d3-time-format": "3",
-        "d3-transition": "^3.0.1"
-      },
-      "devDependencies": {
-        "@babel/cli": "^7.23.9",
-        "@babel/core": "^7.24.0",
-        "@babel/eslint-parser": "^7.23.10",
-        "@babel/plugin-transform-classes": "^7.23.8",
-        "@babel/preset-env": "^7.24.0",
-        "@babel/register": "^7.23.7",
-        "@rollup/plugin-babel": "^6.0.4",
-        "@rollup/plugin-commonjs": "^25.0.7",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@testing-library/cypress": "^10.0.1",
-        "cypress": "^13.6.6",
-        "cypress-localstorage-commands": "^2.2.5",
-        "eslint": "^8.57.0",
-        "mocha": "^10.3.0",
-        "nyc": "^15.1.0",
-        "prettier": "^3.2.5",
-        "rollup": "^4.12.0",
-        "rollup-plugin-livereload": "^2.0.5",
-        "rollup-plugin-local-resolve": "^1.0.7",
-        "rollup-plugin-postcss": "^4.0.2",
-        "rollup-plugin-serve": "^1.1.1"
-      },
-      "peerDependencies": {
-        "d3": "^7.0.0"
       }
     },
     "3rdparty/cubism-es": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.3",
   "description": "A panel to display cubism like graph in grafana",
   "scripts": {
-    "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "typecheck": "tsc --noEmit",

--- a/provisioning/dashboards/dashboard2.json
+++ b/provisioning/dashboards/dashboard2.json
@@ -1,0 +1,78 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource",
+        "uid": "a0ce46a5-c7f8-4cec-997c-6314adf138a1"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "automaticExtents": true,
+        "extentMax": 10,
+        "extentMin": -10,
+        "seriesCountSize": "sm",
+        "showSeriesCount": false,
+        "text": ""
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource",
+            "uid": "a0ce46a5-c7f8-4cec-997c-6314adf138a1"
+          },
+          "max": 10,
+          "min": -5,
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 10
+        }
+      ],
+      "title": "Demo single",
+      "type": "ekacnet-cubismgrafana-panel"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Single panel dashboard",
+  "uid": "f930d956-0144-49fb-87dd-9c3d4a558e03",
+  "version": 2,
+  "weekStart": ""
+}

--- a/provisioning/dashboards/dashboard3.json
+++ b/provisioning/dashboards/dashboard3.json
@@ -1,0 +1,112 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "marcusolsson-csv-datasource",
+        "uid": "a0ce46a5-c7f8-4cec-997c-6314adf138a2"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "automaticExtents": true,
+        "extentMax": 10,
+        "extentMin": -10,
+        "text": ""
+      },
+      "pluginVersion": "10.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "marcusolsson-csv-datasource",
+            "uid": "a0ce46a5-c7f8-4cec-997c-6314adf138a2"
+          },
+          "decimalSeparator": ".",
+          "delimiter": ",",
+          "header": true,
+          "ignoreUnknown": true,
+          "refId": "A",
+          "schema": [
+            {
+              "name": "aggregator-668c9957c7-btfgg",
+              "type": "number"
+            },
+            {
+              "name": "Time",
+              "type": "time"
+            }
+          ],
+          "skipRows": 0,
+          "timezone": "America/Los_Angeles"
+        },
+        {
+          "datasource": {
+            "type": "marcusolsson-csv-datasource",
+            "uid": "a0ce46a5-c7f8-4cec-997c-6314adf138a2"
+          },
+          "decimalSeparator": ".",
+          "delimiter": ",",
+          "header": true,
+          "hide": false,
+          "ignoreUnknown": true,
+          "refId": "B",
+          "schema": [
+            {
+              "name": "Time",
+              "type": "time"
+            },
+            {
+              "name": "aggregator-7469f76bf4-ddmjm",
+              "type": "number"
+            }
+          ],
+          "skipRows": 0,
+          "timezone": "America/Los_Angeles"
+        }
+      ],
+      "title": "Aggregator CPU",
+      "type": "ekacnet-cubismgrafana-panel"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "2024-04-17T03:28:45.000Z",
+    "to": "2024-04-17T05:49:15.000Z"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "K8s PODs",
+  "uid": "fdc65402-092c-4a87-9dd8-6112d7909fb9",
+  "version": 4,
+  "weekStart": ""

--- a/provisioning/dashboards/dashboard4.json
+++ b/provisioning/dashboards/dashboard4.json
@@ -1,0 +1,77 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "aaad26df-aaa4-4734-9904-74004d9a2d78"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "automaticExtents": false,
+        "extentMax": 50,
+        "extentMin": -10,
+        "text": ""
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "aaad26df-aaa4-4734-9904-74004d9a2d78"
+          },
+          "editorMode": "code",
+          "expr": "process_cpu_seconds_total",
+          "instant": false,
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU containers",
+      "type": "ekacnet-cubismgrafana-panel"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "2024-04-17T05:23:05.839Z",
+    "to": "2024-04-19T05:23:05.839Z"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CPU",
+  "uid": "ebcbe55f-f9ab-4f92-ab37-0311a0db5043",
+  "version": 3,
+  "weekStart": ""
+}

--- a/provisioning/datasources/default.yaml
+++ b/provisioning/datasources/default.yaml
@@ -4,3 +4,15 @@ datasources:
   - name: grafana-testdata-datasource
     type: testdata
     uid: a0ce46a5-c7f8-4cec-997c-6314adf138a1
+  - name: csv-testdata-datasource
+    type: marcusolsson-csv-datasource
+    uid: a0ce46a5-c7f8-4cec-997c-6314adf138a2
+    url: /tmp/pods.csv
+    jsonData:
+      storage: local
+  - name: prometheus
+    type: prometheus
+    uid: aaad26df-aaa4-4734-9904-74004d9a2d78
+    url: http://172.23.0.3:9090
+    jsonData:
+      httpMethod: POST

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,0 +1,28 @@
+import type { Configuration } from 'webpack';
+import { mergeWithRules } from 'webpack-merge';
+import grafanaConfig from './.config/webpack/webpack.config';
+
+const config = async (env: any): Promise<Configuration> => {
+  const baseConfig = await grafanaConfig(env);
+  const customConfig = {
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          enforce: "pre",
+          use: ["source-map-loader"],
+        }
+      ]
+    },
+    mode: 'development'
+  }
+  return mergeWithRules({
+    module: {
+      rules: {
+        exclude: 'replace',
+      },
+    },
+  })(baseConfig, customConfig);
+};
+
+export default config;


### PR DESCRIPTION
With devtools set to `source-map` and mode to `production` it's
impossible as of April 2024 to add breakpoints in both firefox and
chrome.

It does lead to a somewhat small file but at the cost of debugability.
When using `eval-source-map` for devtools no matter what is the mode you
can properly debug but the resulting file is fairly large (800K).

Finally using mode `development` allows to debug and the resulting file
is "only" twice as large so we will settle on that.

Signed-off-by: Matthieu Patou <mat@matws.net>
