### PR TITLE
Links are not always defined, check before using

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Start grafana docker
         if: steps.check-for-e2e.outputs.has-e2e == 'true'
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Run e2e tests
         id: run-e2e-tests
@@ -94,7 +94,7 @@ jobs:
 
       - name: Stop grafana docker
         if: steps.check-for-e2e.outputs.has-e2e == 'true'
-        run: docker-compose down
+        run: docker compose down
 
       - name: Sign plugin
         run: npm run sign

--- a/src/components/DataLinksEditor.tsx
+++ b/src/components/DataLinksEditor.tsx
@@ -11,10 +11,10 @@ const DataLinkEditorWarning: React.FC<{
 }> = ({ links}) => {
     let msg = "";
     let prefix ="";
-    if (links.length > 1) {
+    if (links && links.length > 1) {
         prefix ="⚠"
         msg = "more than one link is not supported for cubism";
-    } else if (links.length === 1) {
+    } else if (links && links.length === 1) {
         let url = links[0].url
         const pattern = /\${[^}]*}/g;
         const extractedVariables: string[] = url.match(pattern)!;


### PR DESCRIPTION
This should fix https://github.com/ekacnet/grafanacubism-panel/issues/29.

We were trying to always access `links` even when it didn't exists ...
